### PR TITLE
GS-729b: A cleaner fix changes code in the lower layer.

### DIFF
--- a/auth.php
+++ b/auth.php
@@ -351,7 +351,12 @@ class auth_plugin_enrolkey extends auth_plugin_base {
      */
     private function get_enrol_plugins(moodle_database $db, string $enrolkey) : array {
         // Password is the Enrolment key that is specified in the Self enrolment instance.
-        $enrolplugins = $db->get_records('enrol', ['enrol' => 'self', 'password' => $enrolkey]);
+        if ($enrolkey != '') {
+            $enrolplugins = $db->get_records('enrol', ['enrol' => 'self', 'password' => $enrolkey]);
+        } else {
+            // Avoid the bug that a user created with an empty enrolkey gets enrolled in all courses with `password=''`
+            $enrolplugins = [];
+        }
 
         return array_merge($enrolplugins, $db->get_records_sql("
                 SELECT e.*, g.enrolmentkey

--- a/auth.php
+++ b/auth.php
@@ -244,7 +244,7 @@ class auth_plugin_enrolkey extends auth_plugin_base {
         $errors = [];
 
         // Avoid the bug that a user created with an empty $enrolkey auto-enrols
-        // into all courses with an empty self-enrol and group-enrol key
+        // into all courses with an empty self-enrol or group-enrol key
         if (empty($enrolkey)) {
             return [$availableenrolids, $errors];
         }

--- a/auth.php
+++ b/auth.php
@@ -204,7 +204,7 @@ class auth_plugin_enrolkey extends auth_plugin_base {
             return;
         }
 
-        // Avoid logging in an illegal user after account creation. Redirects to an email sent page.
+        // Avoid logging in an illegal user after account creation. Redirects to an email-sent page.
         if ($user->confirmed === 0 && $user->policyagreed === 0) {
             $this->email_confirmation($user->email);
         }
@@ -243,7 +243,7 @@ class auth_plugin_enrolkey extends auth_plugin_base {
         $availableenrolids = [];
         $errors = [];
 
-        // Avoid the bug that a user created with an empty $enrolkey auto-enrol
+        // Avoid the bug that a user created with an empty $enrolkey auto-enrols
         // into all courses with an empty self-enrol and group-enrol key
         if (empty($enrolkey)) {
             return [$availableenrolids, $errors];

--- a/auth.php
+++ b/auth.php
@@ -354,9 +354,7 @@ class auth_plugin_enrolkey extends auth_plugin_base {
         $enrolplugins = [];
 
         // Password is the Enrolment key that is specified in the Self enrolment instance.
-        if ($enrolkey != '') {
-            $enrolplugins = $db->get_records('enrol', ['enrol' => 'self', 'password' => $enrolkey]);
-        }
+        $enrolplugins = $db->get_records('enrol', ['enrol' => 'self', 'password' => $enrolkey]);
 
         return array_merge($enrolplugins, $db->get_records_sql("
                 SELECT e.*, g.enrolmentkey

--- a/auth.php
+++ b/auth.php
@@ -241,6 +241,13 @@ class auth_plugin_enrolkey extends auth_plugin_base {
         $enrolplugins = $this->get_enrol_plugins($DB, $enrolkey);
         $availableenrolids = [];
         $errors = [];
+
+        // Avoid the bug that a user created with an empty $enrolkey auto-enrol
+        // into all courses with an empty self-enrol and group-enrol key
+        if (empty($enrolkey)) {
+            return [$availableenrolids, $errors];
+        }
+
         foreach ($enrolplugins as $enrolplugin) {
             if ($enrol->can_self_enrol($enrolplugin) === true) {
                 $data = new stdClass();

--- a/auth.php
+++ b/auth.php
@@ -350,9 +350,6 @@ class auth_plugin_enrolkey extends auth_plugin_base {
      * @return array
      */
     private function get_enrol_plugins(moodle_database $db, string $enrolkey) : array {
-        // Avoid the bug that a user created with an empty `$enrolkey` gets enrolled in all courses with `password=''`
-        $enrolplugins = [];
-
         // Password is the Enrolment key that is specified in the Self enrolment instance.
         $enrolplugins = $db->get_records('enrol', ['enrol' => 'self', 'password' => $enrolkey]);
 

--- a/auth.php
+++ b/auth.php
@@ -350,12 +350,12 @@ class auth_plugin_enrolkey extends auth_plugin_base {
      * @return array
      */
     private function get_enrol_plugins(moodle_database $db, string $enrolkey) : array {
+        // Avoid the bug that a user created with an empty `$enrolkey` gets enrolled in all courses with `password=''`
+        $enrolplugins = [];
+
         // Password is the Enrolment key that is specified in the Self enrolment instance.
         if ($enrolkey != '') {
             $enrolplugins = $db->get_records('enrol', ['enrol' => 'self', 'password' => $enrolkey]);
-        } else {
-            // Avoid the bug that a user created with an empty enrolkey gets enrolled in all courses with `password=''`
-            $enrolplugins = [];
         }
 
         return array_merge($enrolplugins, $db->get_records_sql("

--- a/auth.php
+++ b/auth.php
@@ -204,7 +204,8 @@ class auth_plugin_enrolkey extends auth_plugin_base {
             return;
         }
 
-        if (!empty($availableenrolids) && $user->confirmed === 0 && $user->policyagreed === 0) {
+        // Avoid logging in an illegal user after account creation. Redirects to an email sent page.
+        if ($user->confirmed === 0 && $user->policyagreed === 0) {
             $this->email_confirmation($user->email);
         }
 


### PR DESCRIPTION
## Description:
<!-- Describe your changes in detail / numbered list of distinct changes for reference -->
- Fixed the bug where a user created with an empty enrolkey gets enrolled in all self-enrollable courses with `password = ''`.
- Also works for a course allowing group enrolment, whether or not the group enrolment key is empty.
- Similar to the dirty fix online, but moved to a lower layer of function.
- JorritDeKlerk's fix also prevents an illegal user from logging in regardless of whether they enrolled in a course. (We can't trigger these conditions with our log-in GUI.)


## Checklist before requesting a review:
<!-- Remove non-applicable items e.g. epic sub-issue points -->
<!-- Add an 'x' inside the brackets to check the item -->

- [x] I have performed a self review of my code.
- [x] My code follows the [Moodle Coding Style](https://moodledev.io/general/development/policies/codingstyle).
- [x] Code has been commented, particularly in hard-to-understand areas.
